### PR TITLE
Feature/iam identity search parameters

### DIFF
--- a/app/controllers/iam/identities_controller.rb
+++ b/app/controllers/iam/identities_controller.rb
@@ -14,7 +14,30 @@ class Iam::IdentitiesController < ApiController
   CODE_LIST_ATTRIBUTES = [:id, :name]
   
   def show
-    @identity = iam_repository(upvs_identity).identity(params[:id])
+    query_params = params.permit(
+      :personal_identification_number,
+      :given_name,
+      :family_name,
+      :company_registration_number)
+
+    has_id = params[:id].present?
+    has_company_registration_number = query_params[:company_registration_number].present?
+    has_personal_info = query_params[:personal_identification_number].present? &&
+                        query_params[:given_name].present? &&
+                        query_params[:family_name].present?
+
+    unless has_id || has_company_registration_number || has_personal_info
+      render json: { message: 'Either id, company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided' }, status: :bad_request
+      return
+    end
+
+    @identity = iam_repository(upvs_identity).identity(
+      params[:id],
+      personal_identification_number: query_params[:personal_identification_number],
+      given_name: query_params[:given_name],
+      family_name: query_params[:family_name],
+      company_registration_number: query_params[:company_registration_number]
+    )
   end
 
   def search

--- a/app/controllers/iam/identities_controller.rb
+++ b/app/controllers/iam/identities_controller.rb
@@ -26,11 +26,7 @@ class Iam::IdentitiesController < ApiController
     ).to_options
 
     lookup_params = IdentityLookupParams.new(permitted_params)
-
-    unless lookup_params.valid?
-      render json: { message: lookup_params.errors.full_messages.first }, status: :bad_request
-      return
-    end
+    return render_bad_request(:invalid, :query) if lookup_params.invalid?
 
     @identity = iam_repository(upvs_identity).identity(
       nil,

--- a/app/controllers/iam/identities_controller.rb
+++ b/app/controllers/iam/identities_controller.rb
@@ -18,28 +18,26 @@ class Iam::IdentitiesController < ApiController
   end
 
   def lookup
-    query_params = params.permit(
+    permitted_params = params.permit(
       :personal_identification_number,
       :given_name,
       :family_name,
-      :company_registration_number)
+      :company_registration_number
+    ).to_options
 
-    has_company_registration_number = query_params[:company_registration_number].present?
-    has_personal_info = query_params[:personal_identification_number].present? &&
-                        query_params[:given_name].present? &&
-                        query_params[:family_name].present?
+    lookup_params = IdentityLookupParams.new(permitted_params)
 
-    unless has_company_registration_number || has_personal_info
-      render json: { message: 'Either company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided' }, status: :bad_request
+    unless lookup_params.valid?
+      render json: { message: lookup_params.errors.full_messages.first }, status: :bad_request
       return
     end
 
     @identity = iam_repository(upvs_identity).identity(
       nil,
-      personal_identification_number: query_params[:personal_identification_number],
-      given_name: query_params[:given_name],
-      family_name: query_params[:family_name],
-      company_registration_number: query_params[:company_registration_number]
+      personal_identification_number: lookup_params.personal_identification_number,
+      given_name: lookup_params.given_name,
+      family_name: lookup_params.family_name,
+      company_registration_number: lookup_params.company_registration_number
     )
   end
 

--- a/app/controllers/iam/identities_controller.rb
+++ b/app/controllers/iam/identities_controller.rb
@@ -12,27 +12,30 @@ class Iam::IdentitiesController < ApiController
   rescue_from(sk.gov.schemas.identity.service._1_7.GetEdeskInfo2Fault) { |error| render_bad_request(:invalid, :query, upvs_fault(error)) }
 
   CODE_LIST_ATTRIBUTES = [:id, :name]
-  
+
   def show
+    @identity = iam_repository(upvs_identity).identity(params[:id])
+  end
+
+  def lookup
     query_params = params.permit(
       :personal_identification_number,
       :given_name,
       :family_name,
       :company_registration_number)
 
-    has_id = params[:id].present?
     has_company_registration_number = query_params[:company_registration_number].present?
     has_personal_info = query_params[:personal_identification_number].present? &&
                         query_params[:given_name].present? &&
                         query_params[:family_name].present?
 
-    unless has_id || has_company_registration_number || has_personal_info
-      render json: { message: 'Either id, company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided' }, status: :bad_request
+    unless has_company_registration_number || has_personal_info
+      render json: { message: 'Either company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided' }, status: :bad_request
       return
     end
 
     @identity = iam_repository(upvs_identity).identity(
-      params[:id],
+      nil,
       personal_identification_number: query_params[:personal_identification_number],
       given_name: query_params[:given_name],
       family_name: query_params[:family_name],

--- a/app/controllers/iam/identities_controller.rb
+++ b/app/controllers/iam/identities_controller.rb
@@ -8,7 +8,7 @@ class Iam::IdentitiesController < ApiController
 
   before_action(only: :search) { render_bad_request(:missing, :query) if request.request_parameters.blank? }
 
-  rescue_from(sk.gov.schemas.identity.service._1_7.GetIdentityFault) { |error| render_bad_request(:invalid, :identity_id, upvs_fault(error)) }
+  rescue_from(sk.gov.schemas.identity.service._1_7.GetIdentityFault, with: :render_identity_fault)
   rescue_from(sk.gov.schemas.identity.service._1_7.GetEdeskInfo2Fault) { |error| render_bad_request(:invalid, :query, upvs_fault(error)) }
 
   CODE_LIST_ATTRIBUTES = [:id, :name]
@@ -49,5 +49,12 @@ class Iam::IdentitiesController < ApiController
     )
 
     @identities = iam_repository(upvs_identity).search(query.to_options.merge(page: page, per_page: per_page))
+  end
+
+  private
+
+  def render_identity_fault(error)
+    param = action_name == 'show' ? :identity_id : :query
+    render_bad_request(:invalid, param, upvs_fault(error))
   end
 end

--- a/app/models/identity_lookup_params.rb
+++ b/app/models/identity_lookup_params.rb
@@ -1,0 +1,24 @@
+class IdentityLookupParams
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :personal_identification_number, :string
+  attribute :given_name, :string
+  attribute :family_name, :string
+  attribute :company_registration_number, :string
+
+  validate :validate_search_criteria
+
+  private
+
+  def validate_search_criteria
+    has_company_registration_number = company_registration_number.present?
+    has_personal_info = personal_identification_number.present? &&
+                        given_name.present? &&
+                        family_name.present?
+
+    return if has_company_registration_number || has_personal_info
+
+    errors.add(:base, 'Either company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided')
+  end
+end

--- a/app/models/identity_lookup_params.rb
+++ b/app/models/identity_lookup_params.rb
@@ -19,6 +19,6 @@ class IdentityLookupParams
 
     return if has_company_registration_number || has_personal_info
 
-    errors.add(:base, 'Either company_registration_number, or all three of personal_identification_number, given_name, and family_name must be provided')
+    errors.add(:base, :invalid)
   end
 end

--- a/app/services/iam_repository.rb
+++ b/app/services/iam_repository.rb
@@ -3,9 +3,13 @@ class IamRepository
     @upvs = proxy
   end
 
-  def identity(id)
+  def identity(id = nil, personal_identification_number: nil, given_name: nil, family_name: nil, company_registration_number: nil)
     request = factory.create_get_identity_request
-    request.identity_id = id
+    request.identity_id = id if id
+    request.personal_identification_number = personal_identification_number if personal_identification_number
+    request.given_name = given_name if given_name
+    request.family_name = family_name if family_name
+    request.company_registration_number = company_registration_number if company_registration_number
 
     @upvs.iam.get_identity(request).identity_data
   end

--- a/app/views/iam/identities/lookup.json.jbuilder
+++ b/app/views/iam/identities/lookup.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'iam/identity', identity: @identity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       namespace :iam do
         resources :identities, only: [:show] do
           collection do
+            get :show, path: ''
             post :search
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
       namespace :iam do
         resources :identities, only: [:show] do
           collection do
-            get :show, path: ''
+            get :lookup
             post :search
           end
         end

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1951,12 +1951,72 @@ paths:
       security:
         - 'API Token': []
 
+  /api/iam/identities:
+    get:
+      tags: [Vyhľadávanie identít (dostupné len pre OVM)]
+      summary: Vráti identitu podľa osobných údajov alebo IČO
+      description: |
+        Vráti identitu na základe osobných údajov alebo IČO.
+
+        Možné spôsoby vyhľadávania:
+        - IČO (company_registration_number) samostatne, alebo
+        - Všetky tri parametre spoločne: rodné číslo (personal_identification_number), krstné meno (given_name) a priezvisko (family_name)
+
+        Pozor, volanie je dostupné len pre OVM.
+      parameters:
+        - name: personal_identification_number
+          in: query
+          required: false
+          description: Rodné číslo fyzickej osoby. Vyžadované spolu s given_name a family_name, ak nie je poskytnuté company_registration_number.
+          schema:
+            type: string
+            example: '1234567890'
+        - name: given_name
+          in: query
+          required: false
+          description: Krstné meno fyzickej osoby. Vyžadované spolu s personal_identification_number a family_name, ak nie je poskytnuté company_registration_number.
+          schema:
+            type: string
+            example: 'Ján'
+        - name: family_name
+          in: query
+          required: false
+          description: Priezvisko fyzickej osoby. Vyžadované spolu s personal_identification_number a given_name, ak nie je poskytnuté company_registration_number.
+          schema:
+            type: string
+            example: 'Novák'
+        - name: company_registration_number
+          in: query
+          required: false
+          description: IČO právnickej osoby. Môže byť použité samostatne na vyhľadávanie.
+          schema:
+            type: string
+            example: '12345678'
+      responses:
+        200:
+          description: Úspešne vrátená identita.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UpvsCorporateBody'
+                  - $ref: '#/components/schemas/UpvsNaturalPerson'
+              examples:
+                'Právnická osoba':
+                  value:
+                    $ref: '#/components/schemas/UpvsCorporateBody/example'
+                'Fyzická osoba':
+                  value:
+                    $ref: '#/components/schemas/UpvsNaturalPerson/example'
+      security:
+        - 'API Token': []
+
   /api/iam/identities/{id}:
     get:
       tags: [Vyhľadávanie identít (dostupné len pre OVM)]
-      summary: Vráti identitu
+      summary: Vráti identitu podľa ID
       description: |
-        Vráti identitu.
+        Vráti identitu na základe ID identity.
 
         Pozor, volanie je dostupné len pre OVM.
       parameters:
@@ -1968,6 +2028,34 @@ paths:
             type: string
             format: uuid
             example: 6d9dc77b-70ed-432f-abaa-5de8753c967c
+        - name: personal_identification_number
+          in: query
+          required: false
+          description: Rodné číslo fyzickej osoby (voliteľné, pre dodatočnú validáciu).
+          schema:
+            type: string
+            example: '1234567890'
+        - name: given_name
+          in: query
+          required: false
+          description: Krstné meno fyzickej osoby (voliteľné, pre dodatočnú validáciu).
+          schema:
+            type: string
+            example: 'Ján'
+        - name: family_name
+          in: query
+          required: false
+          description: Priezvisko fyzickej osoby (voliteľné, pre dodatočnú validáciu).
+          schema:
+            type: string
+            example: 'Novák'
+        - name: company_registration_number
+          in: query
+          required: false
+          description: IČO právnickej osoby (voliteľné).
+          schema:
+            type: string
+            example: '12345678'
       responses:
         200:
           description: Úspešne vrátená identita.

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: slovensko.sk API
-  version: 3.8.1 (Komunitná verzia) 8.9.1 (Prémium verzia)
+  version: 3.8.2 (Komunitná verzia) 8.9.2 (Prémium verzia)
 
   description: |
     slovensko.sk API je proxy REST API komponent k službám www.slovensko.sk (Ústredný portál verejnej správy – ÚPVS), pomocou ktorých je možné:
@@ -1951,7 +1951,43 @@ paths:
       security:
         - 'API Token': []
 
-  /api/iam/identities:
+  /api/iam/identities/{id}:
+    get:
+      tags: [Vyhľadávanie identít (dostupné len pre OVM)]
+      summary: Vráti identitu podľa ID
+      description: |
+        Vráti identitu na základe ID identity.
+
+        Pozor, volanie je dostupné len pre OVM.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID identity.
+          schema:
+            type: string
+            format: uuid
+            example: 6d9dc77b-70ed-432f-abaa-5de8753c967c
+      responses:
+        200:
+          description: Úspešne vrátená identita.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UpvsCorporateBody'
+                  - $ref: '#/components/schemas/UpvsNaturalPerson'
+              examples:
+                'Právnická osoba':
+                  value:
+                    $ref: '#/components/schemas/UpvsCorporateBody/example'
+                'Fyzická osoba':
+                  value:
+                    $ref: '#/components/schemas/UpvsNaturalPerson/example'
+      security:
+        - 'API Token': []
+
+  /api/iam/identities/lookup:
     get:
       tags: [Vyhľadávanie identít (dostupné len pre OVM)]
       summary: Vráti identitu podľa osobných údajov alebo IČO
@@ -1989,70 +2025,6 @@ paths:
           in: query
           required: false
           description: IČO právnickej osoby. Môže byť použité samostatne na vyhľadávanie.
-          schema:
-            type: string
-            example: '12345678'
-      responses:
-        200:
-          description: Úspešne vrátená identita.
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/UpvsCorporateBody'
-                  - $ref: '#/components/schemas/UpvsNaturalPerson'
-              examples:
-                'Právnická osoba':
-                  value:
-                    $ref: '#/components/schemas/UpvsCorporateBody/example'
-                'Fyzická osoba':
-                  value:
-                    $ref: '#/components/schemas/UpvsNaturalPerson/example'
-      security:
-        - 'API Token': []
-
-  /api/iam/identities/{id}:
-    get:
-      tags: [Vyhľadávanie identít (dostupné len pre OVM)]
-      summary: Vráti identitu podľa ID
-      description: |
-        Vráti identitu na základe ID identity.
-
-        Pozor, volanie je dostupné len pre OVM.
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: ID identity.
-          schema:
-            type: string
-            format: uuid
-            example: 6d9dc77b-70ed-432f-abaa-5de8753c967c
-        - name: personal_identification_number
-          in: query
-          required: false
-          description: Rodné číslo fyzickej osoby (voliteľné, pre dodatočnú validáciu).
-          schema:
-            type: string
-            example: '1234567890'
-        - name: given_name
-          in: query
-          required: false
-          description: Krstné meno fyzickej osoby (voliteľné, pre dodatočnú validáciu).
-          schema:
-            type: string
-            example: 'Ján'
-        - name: family_name
-          in: query
-          required: false
-          description: Priezvisko fyzickej osoby (voliteľné, pre dodatočnú validáciu).
-          schema:
-            type: string
-            example: 'Novák'
-        - name: company_registration_number
-          in: query
-          required: false
-          description: IČO právnickej osoby (voliteľné).
           schema:
             type: string
             example: '12345678'

--- a/spec/requests/api/iam_spec.rb
+++ b/spec/requests/api/iam_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'IAM API' do
       get '/api/iam/identities/lookup', headers: headers
 
       expect(response.status).to eq(400)
-      expect(response.object[:message]).to include('company_registration_number')
+      expect(response.object).to eq(message: 'Invalid query')
     end
 
     it 'responds with 400 if only partial personal info is provided' do
@@ -139,7 +139,7 @@ RSpec.describe 'IAM API' do
           }
 
       expect(response.status).to eq(400)
-      expect(response.object[:message]).to include('company_registration_number')
+      expect(response.object).to eq(message: 'Invalid query')
     end
 
     include_examples 'API request media types', get: '/api/iam/identities/lookup', accept: 'application/json' do

--- a/spec/requests/api/iam_spec.rb
+++ b/spec/requests/api/iam_spec.rb
@@ -150,6 +150,53 @@ RSpec.describe 'IAM API' do
       let(:params) { { company_registration_number: '12345678' } }
     end
 
+    it 'responds with 400 if IAM raises identifier fault' do
+      expect(upvs.iam).to receive(:get_identity).with(kind_of(sk.gov.schemas.identity.service._1.GetIdentityRequest)).and_raise(iam_get_identity_fault('iam/get_identity/invalid_identifier_fault.xml'))
+
+      get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
+
+      expect(response.status).to eq(400)
+      expect(response.object).to eq(message: 'Invalid identity identifier', fault: { code: '00074421', reason: 'Nastala chyba: IDENTITY_ID_FAULT' })
+    end
+
+    it 'responds with 400 if IAM raises IAM fault' do
+      expect(upvs.iam).to receive(:get_identity).with(kind_of(sk.gov.schemas.identity.service._1.GetIdentityRequest)).and_raise(iam_get_identity_fault('iam/get_identity/undefined_fault.xml'))
+
+      get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
+
+      expect(response.status).to eq(400)
+      expect(response.object).to eq(message: 'Invalid identity identifier', fault: { code: '00000000', reason: 'Nedefinovaná chyba!' })
+    end
+
+    it 'responds with 408 if IAM raises timeout error' do
+      expect(upvs.iam).to receive(:get_identity).and_raise(soap_timeout_exception)
+
+      get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
+
+      expect(response.status).to eq(408)
+      expect(response.object).to eq(message: 'Operation timeout exceeded')
+    end
+
+    pending 'responds with 429 if request rate limit exceeds'
+
+    it 'responds with 500 if IAM raises internal error' do
+      expect(upvs.iam).to receive(:get_identity).and_raise
+
+      get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
+
+      expect(response.status).to eq(500)
+      expect(response.object).to eq(message: 'Unknown error')
+    end
+
+    it 'responds with 503 if IAM raises SOAP fault' do
+      expect(upvs.iam).to receive(:get_identity).and_raise(soap_fault_exception)
+
+      get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
+
+      expect(response.status).to eq(503)
+      expect(response.object).to eq(message: 'Unknown failure')
+    end
+
     include_examples 'UPVS proxy initialization', get: '/api/iam/identities/lookup', allow_sub: true do
       let(:params) { { company_registration_number: '12345678' } }
     end

--- a/spec/requests/api/iam_spec.rb
+++ b/spec/requests/api/iam_spec.rb
@@ -22,92 +22,6 @@ RSpec.describe 'IAM API' do
       expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
     end
 
-    it 'returns identity with optional query parameters' do
-      expect(upvs.iam).to receive(:get_identity).with(
-        satisfy do |request|
-          request.identity_id == '6d9dc77b-70ed-432f-abaa-5de8753c967c' &&
-          request.personal_identification_number == '1234567890' &&
-          request.given_name == 'John' &&
-          request.family_name == 'Doe' &&
-          request.company_registration_number == '12345678'
-        end
-      ).and_return(iam_response('iam/get_identity_response.xml'))
-
-      get '/api/iam/identities/6d9dc77b-70ed-432f-abaa-5de8753c967c',
-          headers: headers,
-          params: {
-            personal_identification_number: '1234567890',
-            given_name: 'John',
-            family_name: 'Doe',
-            company_registration_number: '12345678'
-          }
-
-      expect(response.status).to eq(200)
-      expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
-    end
-
-    it 'returns identity when searching by personal info without id' do
-      expect(upvs.iam).to receive(:get_identity).with(
-        satisfy do |request|
-          request.identity_id.nil? &&
-          request.personal_identification_number == '1234567890' &&
-          request.given_name == 'John' &&
-          request.family_name == 'Doe'
-        end
-      ).and_return(iam_response('iam/get_identity_response.xml'))
-
-      get '/api/iam/identities/',
-          headers: headers,
-          params: {
-            personal_identification_number: '1234567890',
-            given_name: 'John',
-            family_name: 'Doe'
-          }
-
-      expect(response.status).to eq(200)
-      expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
-    end
-
-    it 'returns identity when searching by company registration number only' do
-      expect(upvs.iam).to receive(:get_identity).with(
-        satisfy do |request|
-          request.identity_id.nil? &&
-          request.company_registration_number == '12345678' &&
-          request.personal_identification_number.nil? &&
-          request.given_name.nil? &&
-          request.family_name.nil?
-        end
-      ).and_return(iam_response('iam/get_identity_response.xml'))
-
-      get '/api/iam/identities/',
-          headers: headers,
-          params: {
-            company_registration_number: '12345678'
-          }
-
-      expect(response.status).to eq(200)
-      expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
-    end
-
-    it 'responds with 400 if no valid search parameters are provided' do
-      get '/api/iam/identities/', headers: headers
-
-      expect(response.status).to eq(400)
-      expect(response.object[:message]).to include('Either id, company_registration_number')
-    end
-
-    it 'responds with 400 if only partial personal info is provided' do
-      get '/api/iam/identities/',
-          headers: headers,
-          params: {
-            personal_identification_number: '1234567890',
-            given_name: 'John'
-          }
-
-      expect(response.status).to eq(400)
-      expect(response.object[:message]).to include('Either id, company_registration_number')
-    end
-
     include_examples 'API request media types', get: '/api/iam/identities/6d9dc77b-70ed-432f-abaa-5de8753c967c', accept: 'application/json'
     include_examples 'API request authentication', get: '/api/iam/identities/6d9dc77b-70ed-432f-abaa-5de8753c967c', allow_sub: true
 
@@ -159,6 +73,86 @@ RSpec.describe 'IAM API' do
     end
 
     include_examples 'UPVS proxy initialization', get: '/api/iam/identities/6d9dc77b-70ed-432f-abaa-5de8753c967c', allow_sub: true
+  end
+
+  describe 'GET /api/iam/identities/lookup' do
+    def set_upvs_expectations
+      expect(upvs.iam).to receive(:get_identity).with(kind_of(sk.gov.schemas.identity.service._1.GetIdentityRequest)).and_return(iam_response('iam/get_identity_response.xml'))
+    end
+
+    it 'returns identity when searching by personal info' do
+      expect(upvs.iam).to receive(:get_identity).with(
+        satisfy do |request|
+          request.identity_id.nil? &&
+          request.personal_identification_number == '1234567890' &&
+          request.given_name == 'John' &&
+          request.family_name == 'Doe'
+        end
+      ).and_return(iam_response('iam/get_identity_response.xml'))
+
+      get '/api/iam/identities/lookup',
+          headers: headers,
+          params: {
+            personal_identification_number: '1234567890',
+            given_name: 'John',
+            family_name: 'Doe'
+          }
+
+      expect(response.status).to eq(200)
+      expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
+    end
+
+    it 'returns identity when searching by company registration number only' do
+      expect(upvs.iam).to receive(:get_identity).with(
+        satisfy do |request|
+          request.identity_id.nil? &&
+          request.company_registration_number == '12345678' &&
+          request.personal_identification_number.nil? &&
+          request.given_name.nil? &&
+          request.family_name.nil?
+        end
+      ).and_return(iam_response('iam/get_identity_response.xml'))
+
+      get '/api/iam/identities/lookup',
+          headers: headers,
+          params: {
+            company_registration_number: '12345678'
+          }
+
+      expect(response.status).to eq(200)
+      expect(response.object).to eq(JSON.parse(file_fixture('api/iam/identity.json').read, symbolize_names: true))
+    end
+
+    it 'responds with 400 if no valid search parameters are provided' do
+      get '/api/iam/identities/lookup', headers: headers
+
+      expect(response.status).to eq(400)
+      expect(response.object[:message]).to include('company_registration_number')
+    end
+
+    it 'responds with 400 if only partial personal info is provided' do
+      get '/api/iam/identities/lookup',
+          headers: headers,
+          params: {
+            personal_identification_number: '1234567890',
+            given_name: 'John'
+          }
+
+      expect(response.status).to eq(400)
+      expect(response.object[:message]).to include('company_registration_number')
+    end
+
+    include_examples 'API request media types', get: '/api/iam/identities/lookup', accept: 'application/json' do
+      let(:params) { { company_registration_number: '12345678' } }
+    end
+
+    include_examples 'API request authentication', get: '/api/iam/identities/lookup', allow_sub: true do
+      let(:params) { { company_registration_number: '12345678' } }
+    end
+
+    include_examples 'UPVS proxy initialization', get: '/api/iam/identities/lookup', allow_sub: true do
+      let(:params) { { company_registration_number: '12345678' } }
+    end
   end
 
   describe 'POST /api/iam/identities/search' do

--- a/spec/requests/api/iam_spec.rb
+++ b/spec/requests/api/iam_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'IAM API' do
       get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
 
       expect(response.status).to eq(400)
-      expect(response.object).to eq(message: 'Invalid identity identifier', fault: { code: '00074421', reason: 'Nastala chyba: IDENTITY_ID_FAULT' })
+      expect(response.object).to eq(message: 'Invalid query', fault: { code: '00074421', reason: 'Nastala chyba: IDENTITY_ID_FAULT' })
     end
 
     it 'responds with 400 if IAM raises IAM fault' do
@@ -165,7 +165,7 @@ RSpec.describe 'IAM API' do
       get '/api/iam/identities/lookup', headers: headers, params: { company_registration_number: '12345678' }
 
       expect(response.status).to eq(400)
-      expect(response.object).to eq(message: 'Invalid identity identifier', fault: { code: '00000000', reason: 'Nedefinovaná chyba!' })
+      expect(response.object).to eq(message: 'Invalid query', fault: { code: '00000000', reason: 'Nedefinovaná chyba!' })
     end
 
     it 'responds with 408 if IAM raises timeout error' do


### PR DESCRIPTION
## Summary
Extends the IAM identity endpoint to support searching by company registration number or personal information without requiring an identity ID.

## Changes
- Added collection endpoint `GET /api/iam/identities/` for searching without ID
- Added optional query parameters to `GET /api/iam/identities/{id}`
- Updated OpenAPI documentation
- Added validation for search parameter combinations

## Backward Compatibility
Fully backward compatible - existing API calls work unchanged